### PR TITLE
[fix]: Se eliminan variables para la visualizacion de alertas 

### DIFF
--- a/clase20-20231003/00-LoginClaseAnterior/src/routes/vistas.router.js
+++ b/clase20-20231003/00-LoginClaseAnterior/src/routes/vistas.router.js
@@ -34,41 +34,72 @@ router.get('/',(req,res)=>{
 
 router.get('/registro',auth2,(req,res)=>{
 
-    let error=false
-    let errorDetalle=''
-    if(req.query.error){
-        error=true
-        errorDetalle=req.query.error
-    }
+    // let error=false
+    // let errorDetalle='';
 
+    // if(req.query.error){
+    //     // error=true
+    //     errorDetalle=req.query.error;
+    // }
+    
+    // res.status(200).render('registro',{
+    //     verLogin:true,
+    //     errorDetalle
+    //     // error,
+    // })
+    
+    
+    // [fix]: Podemos notar que en JS un string cualquiera no vacio es considerado true
+    // Esto nos permite declarar la variable error
+    let errorDetalle='';
+    
+    if(req.query.error) errorDetalle=req.query.error;
+    
     res.status(200).render('registro',{
         verLogin:true,
-        error, errorDetalle
+        errorDetalle
     })
 })
 
 router.get('/login',auth2,(req,res)=>{
 
-    let error=false
-    let errorDetalle=''
-    if(req.query.error){
-        error=true
-        errorDetalle=req.query.error
-    }
+    // // let error=false
+    // let errorDetalle=''
+    // if(req.query.error){
+    //     // error=true
+    //     errorDetalle=req.query.error
+    // }
 
-    let usuarioCreado=false
-    let usuarioCreadoDetalle=''
-    if(req.query.usuarioCreado){
-        usuarioCreado=true
-        usuarioCreadoDetalle=req.query.usuarioCreado
-    }
+    // // let usuarioCreado=false
+    // let usuarioCreadoDetalle=''
+    // if(req.query.usuarioCreado){
+    //     // usuarioCreado=true
+    //     usuarioCreadoDetalle=req.query.usuarioCreado
+    // }
 
 
 
+    // res.status(200).render('login',{
+    //     verLogin:true,
+    //     // error, usuarioCreado, 
+    //     usuarioCreadoDetalle,
+    //     errorDetalle
+    // })
+
+    // [fix]: Mismo que en el caso del registro de usuarios
+
+    let errorDetalle='', usuarioCreadoDetalle='';
+
+    let {error, usuarioCreado} = req.query;
+    
+    if(error) errorDetalle = error;
+    
+    if(usuarioCreado) usuarioCreadoDetalle = usuarioCreado;
+    
     res.status(200).render('login',{
         verLogin:true,
-        usuarioCreado, usuarioCreadoDetalle,
-        error, errorDetalle
+        errorDetalle, 
+        usuarioCreadoDetalle
     })
 })
 

--- a/clase20-20231003/00-LoginClaseAnterior/src/views/login.handlebars
+++ b/clase20-20231003/00-LoginClaseAnterior/src/views/login.handlebars
@@ -2,11 +2,21 @@
 <hr>
 <form action="/api/sessions/login" method="post">
 
-    {{#if error}}
+    {{!-- {{#if error}}
         <div class="error">{{errorDetalle}}</div>
     {{/if}}
-
+    
     {{#if usuarioCreado}}
+        <div class="success">Se ha creado correctamente el usuario {{usuarioCreadoDetalle}}</div>
+    {{/if}} --}}
+
+    {{!-- [fix]: Con pasar solo errorDetalle o ver si el usuario fue creado exitosamente, nos basta para saber si mostrar o no la alerta --}}
+
+    {{#if errorDetalle}}
+        <div class="error">{{errorDetalle}}</div>
+    {{/if}}
+    
+    {{#if usuarioCreadoDetalle}}
         <div class="success">Se ha creado correctamente el usuario {{usuarioCreadoDetalle}}</div>
     {{/if}}
 

--- a/clase20-20231003/00-LoginClaseAnterior/src/views/registro.handlebars
+++ b/clase20-20231003/00-LoginClaseAnterior/src/views/registro.handlebars
@@ -2,7 +2,12 @@
 <hr>
 <form action="/api/sessions/registro" method="post">
 
-    {{#if error}}
+    {{!-- {{#if error}}
+        <div class="error">{{errorDetalle}}</div>
+    {{/if}} --}}
+
+    {{!-- [fix]: Con pasar solo errorDetalle, nos basta para saber si mostrar o no la alerta --}}
+    {{#if errorDetalle}}
         <div class="error">{{errorDetalle}}</div>
     {{/if}}
 

--- a/clase22-20231010/00-JWT/src/app.js
+++ b/clase22-20231010/00-JWT/src/app.js
@@ -66,9 +66,7 @@ app.post('/login',(req,res)=>{
 
 })
 
-app.get('/usuario',validarJWT,(req,res)=>{
-
-
+app.get('/usuario', validarJWT, (req, res) => {
     res.setHeader('Content-Type','application/json');
     res.status(200).json({
         mensaje:'Bienvenido...!!!',

--- a/clase22-20231010/00-JWT/src/utils.js
+++ b/clase22-20231010/00-JWT/src/utils.js
@@ -12,20 +12,26 @@ const PRIVATE_KEY='secretPass'
 export const generaJWT=(usuario)=>jwt.sign({usuario},PRIVATE_KEY,{expiresIn:'1h'})
 
 export const validarJWT=(req, res, next)=>{
-    // Bearer token  authorization
-    let authHeader=req.headers.authorization
-    if(!authHeader) return res.status(401).json({error:"No existe token"})
+     // Bearer token  authorization
+    
+     //  Queremos ver si existe la cabecera de autorizacion. Si no existe se arroja error
+     // y si existe, tomar el Bearer token, quedarnos solo con el token y pasarlo por una 
+     // funcion de validacion del objeto JWT 
+    let authHeader=req.headers.authorization; // se chequea si existe el header authorization
+    if(!authHeader) return res.status(401).json({error:"No existe token"});
 
-    let token=authHeader.split(' ')[1]
+    // authHeader retorna Bearer token. Entonces separo el string con split cada vez que
+    // hay un espacio (con esto obtengo [Bearer, token]) y como quiero el token
+    // accedo a la posicion 1
+    let token = authHeader.split(' ')[1];  
 
-    jwt.verify(token, PRIVATE_KEY, (error, credenciales)=>{
+    jwt.verify(token, PRIVATE_KEY, (error, credenciales) => {
         if(error) return res.status(401).json({error:"Token invalido"})
 
-        console.log(credenciales)
+        console.log(credenciales); // credenciales es el contenido del token
 
-        req.user=credenciales.usuario
+        req.user = credenciales.usuario;
 
-        next()
+        next();
     })
-
 } // fin validarJWT

--- a/clase22-20231010/01-JWTLocalStorage/src/views/home.handlebars
+++ b/clase22-20231010/01-JWTLocalStorage/src/views/home.handlebars
@@ -13,6 +13,17 @@
 <hr>
 <a href="/usuario" id="linkUsuario">Página Usuarios</a>
 
+{{!-- La idea es loguearse como un usuario. Una vez logueado, 
+accedemos al token generado y al clickear la "Pagina usuarios"
+queremos trasladar el token a una cabecera y que actue cuando
+hacemos click en "Pagina usuarios"  --}}
+
+{{!-- Para ello, vamos a utilizar el local Storage para almacenar el token --}}
+
+{{!-- Por lo tanto, vamos a querer que en lugar que el HTML realice el post
+lo pueda controlar yo y cuando me devuelva el token, guardarlo en el 
+local storage --}}
+
 <script>
     let btnSubmit=document.getElementById('btnSubmit')
     let inputEmail=document.getElementById('email')
@@ -20,7 +31,7 @@
     let divMensaje=document.getElementById('mensaje')
     let linkUsuario=document.getElementById('linkUsuario')
 
-    btnSubmit.addEventListener("click",async(evt)=>{
+    btnSubmit.addEventListener("click", async (evt) => {
         evt.preventDefault()
 
         if(inputEmail.value.trim().length===0 || inputPassword.value.trim().length===0){
@@ -28,52 +39,54 @@
             return
         }
 
-        let body={
+        let body = {
             email: inputEmail.value.trim(),
             password: inputPassword.value.trim()
         }
 
-        let resultado=await fetch('/login', {
+        let resultado = await fetch('/login', {
             method:'post',
             headers:{
                 'Content-Type':'application/json'
             },
             body:JSON.stringify(body)
         })
-        console.log(resultado)
-        if(resultado.status===200){
+
+        console.log(resultado) // obtiene la informacion de la promesa
+        
+        if(resultado.status === 200){
             let datos=await resultado.json()
-            console.log(datos)
+            console.log(datos) // datos devuelve un objeto con dos props: usuarioLogueado y token
+            // datos.usuarioLogueado contiene el id, nombre, email y password
 
             localStorage.setItem('coderToken',datos.token)
-            divMensaje.innerHTML=`Usuario logueado OK. ${datos.usuarioLogueado.nombre}`
+            divMensaje.innerHTML = `Usuario logueado OK. ${datos.usuarioLogueado.nombre}`
         }else{
             divMensaje.innerHTML='Error de login'
         }
 
     }) // fin fn btnSubmit
 
-    linkUsuario.addEventListener("click",async(evt)=>{
-        evt.preventDefault()
+    // Codigo para cuando se clickea pagina de usuario una vez que esta logeado
+    linkUsuario.addEventListener("click", async (evt) => {
+        evt.preventDefault();
 
-        let resultado= await fetch('/usuario',{
+        let resultado = await fetch('/usuario',{
             method:'get',
             headers:{
                 'Content-Type':'application/json',
-                'Authorization':'Bearer '+localStorage.getItem('coderToken')
+                'Authorization':'Bearer ' + localStorage.getItem('coderToken')
             }
         })
-        let datos=await resultado.json()
+
+        let datos = await resultado.json()
         console.log(resultado)
         console.log(datos)
 
-        if(resultado.status===200){
-            divMensaje.innerHTML=datos.mensaje
+        if(resultado.status === 200){
+            divMensaje.innerHTML = datos.mensaje
         }else{
-            divMensaje.innerHTML=datos.error
+            divMensaje.innerHTML = datos.error
         }
-
     }) // fin fn linkUsuario
-
-
 </script>

--- a/clase22-20231010/02-JWTCookies/src/app.js
+++ b/clase22-20231010/02-JWTCookies/src/app.js
@@ -2,7 +2,7 @@ import express from 'express';
 import fs from 'fs'
 import path from 'path'
 import { engine } from 'express-handlebars';
-import cookieParser from 'cookie-parser'
+import cookieParser from 'cookie-parser'; // importo cookie parser porque ahora voy a enviar el token a traves de una cookie 
 import __dirname, { generaJWT, validaJWT } from './utils.js';
 const PORT = 3000;
 
@@ -14,7 +14,7 @@ app.set('views', path.join(__dirname, '/views'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static('./src/public'))
-app.use(cookieParser())
+app.use(cookieParser()); // inicializacion de cookie parser
 
 app.get('/', (req, res) => {
     // res.setHeader('Content-Type', 'text/html');
@@ -60,15 +60,15 @@ app.post('/login', (req, res) => {
 
     let token = generaJWT(usuario)
 
-    res.cookie('coderCookie',token,{
+    res.cookie('coderCookie', token, {
         maxAge:1000*60*60,
-        httpOnly:true
+        httpOnly:true // con esto evitamos que la cookie pueda ser accedida con la instruccion document.cookie
     })
+
     return res.status(200).json({
         usuarioLogueado: usuario,
         token
     })
-
 })
 
 app.get('/usuario', validaJWT,(req, res) => {

--- a/clase22-20231010/02-JWTCookies/src/utils.js
+++ b/clase22-20231010/02-JWTCookies/src/utils.js
@@ -17,6 +17,8 @@ export const validaJWT=(req, res, next)=>{
 
     // let token=authHeader.split(' ')[1]
 
+    // Ahora, busca el token en las cookies
+
     if(!req.cookies.coderCookie) return res.status(400).json({error:'Error - no existe token'})
 
     console.log("Recupero token, ahora desde una Cookie...!!!")

--- a/clase22-20231010/02-JWTCookies/src/views/home.handlebars
+++ b/clase22-20231010/02-JWTCookies/src/views/home.handlebars
@@ -14,6 +14,9 @@
 <a href="/usuario" id="linkUsuario">Página Usuarios</a>
 
 <script>
+    // Nuevamente, ahora se encarga el HTML de responder.
+    // Por eso, comento el siguiente codigo:
+
     /*
     let btnSubmit=document.getElementById('btnSubmit')
     let inputEmail=document.getElementById('email')

--- a/clase22-20231010/03-JWTPassport/src/app.js
+++ b/clase22-20231010/03-JWTPassport/src/app.js
@@ -17,6 +17,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static('./src/public'))
 app.use(cookieParser())
+
 inicializarPassport()
 app.use(passport.initialize())
 
@@ -76,6 +77,7 @@ app.post('/login', (req, res) => {
 })
 
 // app.get('/usuario', validaJWT,(req, res) => {
+// utilizamos la estrategia imlementada con passport
 app.get('/usuario', passport.authenticate('jwt',{ session:false}),(req, res) => {
 
 

--- a/clase23-20231012/00-clasePrevia/04-PassportMensajes/src/app.js
+++ b/clase23-20231012/00-clasePrevia/04-PassportMensajes/src/app.js
@@ -77,9 +77,10 @@ app.post('/login', (req, res) => {
 
 // app.get('/usuario', validaJWT,(req, res) => {
 // app.get('/usuario', passport.authenticate('jwt',{ session:false }),(req, res) => {
+    
+// Aplico el passport call aca
 app.get('/usuario', passportCall('jwt'),(req, res) => {
-
-
+    
     res.setHeader('Content-Type', 'application/json');
     res.status(200).json({
         mensaje: 'Bienvenido...!!!',

--- a/clase23-20231012/00-clasePrevia/04-PassportMensajes/src/config/passport.config.js
+++ b/clase23-20231012/00-clasePrevia/04-PassportMensajes/src/config/passport.config.js
@@ -24,6 +24,7 @@ export const inicializarPassport=()=>{
         (contenidoJwt ,done)=>{
             try {
                 if(contenidoJwt.usuario.nombre==='Juan'){
+                    // cuando intenta ingresar a su perfil el usuario Juan
                     return done(null, false, {messages:'El usuario Juan esta temporalmente inhabilitado', detalle:'Contacte a RRHH'})
                 }
                 return done(null, contenidoJwt.usuario)

--- a/clase23-20231012/00-clasePrevia/04-PassportMensajes/src/utils.js
+++ b/clase23-20231012/00-clasePrevia/04-PassportMensajes/src/utils.js
@@ -36,7 +36,7 @@ export const validaJWT=(req, res, next)=>{
 
 
 
-export const passportCall=(estrategia)=>{
+export const passportCall = estrategia => {
     return async function(req, res, next){
         passport.authenticate(estrategia, function(err, usuario, info){
             if(err) return next(err)

--- a/clase23-20231012/01-Router-Avanzado/routes/pruebas.router.js
+++ b/clase23-20231012/01-Router-Avanzado/routes/pruebas.router.js
@@ -11,6 +11,7 @@ router.get('/',(req,res)=>{
 });
 
 router.get('/:numero([0-9-.]+)',(req,res)=>{
+    // el simbolo + indica que puede haber varias ocurrencias/repeticiones de [0-9-.] 
     
     res.setHeader('Content-Type','application/json');
     res.status(200).json({
@@ -35,6 +36,7 @@ let errores={
 }
 
 router.param('codigo',(req, res, next, codigo)=>{
+    // para evitar la seccion de errores comentados en los endpoints de abajo 
     let detalleError='Error desconocido'
     if(errores[codigo]){
         detalleError=errores[codigo]
@@ -72,5 +74,6 @@ router.get('/error/:usuario/:codigo',(req,res)=>{
 
 
 router.get('*',(req, res)=>{
+    // cualquier otro endpoint que no haya sido declarado
     res.status(404).send('Page not found')
 })

--- a/clase23-20231012/02-Router-Personalizado/src/routes/router.js
+++ b/clase23-20231012/02-Router-Personalizado/src/routes/router.js
@@ -12,7 +12,13 @@ export class MiRouter{
         return this.router
     }
     
-    get(ruta, permisos, ...funciones){ // operador rest
+    get(ruta, permisos, ...funciones){ 
+        // ... operador rest -> 
+        // cuando se lo llama a get desde el router o una clase que hereda el router 
+        // por ej: get(1,2,3,4,5)
+        // 1 -> ruta
+        // 2,3,4,5 -> a permisos
+    
         console.log({ruta, funciones})
         this.router.get(ruta, this.misRespuestas, this.acceso(permisos) , funciones)
     }
@@ -42,6 +48,9 @@ export class MiRouter{
     }
 
     acceso(permisos=['PUBLIC']){
+        // Permite poder trabajar varios permisos
+        // Es decir, a que endpoints van a poder acceder Administradores, usuarios
+        // o cualquiera
         return (req, res, next)=>{
             if(permisos.includes('PUBLIC')) return next()
 

--- a/clase23-20231012/02-Router-Personalizado/src/routes/usuarios.router.js
+++ b/clase23-20231012/02-Router-Personalizado/src/routes/usuarios.router.js
@@ -1,7 +1,5 @@
 import { MiRouter } from "./router.js";
 
-
-
 export class UsuariosRouter extends MiRouter{
 
     mid01(req, res, next){


### PR DESCRIPTION
 Se elimina la variable error en el endpoint get '/registro' dado que en JS cualquier string no vacio evalua a true y con solo la variable errorDetalle se puede decidir en la vista de registro si mostrar o no la correspondiente alerta.

El caso es analogo para el endpoint get '/login' con las variables error y usuarioCreado.